### PR TITLE
feat: migrate nats-events from streaming to jetstream (3.0.0-rc.1)

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -160,7 +160,16 @@ jobs:
         run: yarn build
 
       - name: Publish to AWS CodeArtifact
-        run: npm publish
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          # Prerelease versions (3.0.0-rc.1 etc.) must publish under a dist-tag
+          # other than 'latest' so default `yarn add` doesn't pick them up.
+          if [[ "${VERSION}" == *-* ]]; then
+            echo "publishing prerelease ${VERSION} under dist-tag 'next'"
+            npm publish --tag next
+          else
+            npm publish
+          fi
 
   dependency-review:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caytu/shared",
-  "version": "3.0.0-rc.1",
+  "version": "3.0.0-rc.2",
   "description": "Shared Library for Caytu",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caytu/shared",
-  "version": "2.0.267",
+  "version": "3.0.0-rc.1",
   "description": "Shared Library for Caytu",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
@@ -203,7 +203,6 @@
     "mongoose": "^6.13.8",
     "mongoose-geojson-schema": "^2.2.4",
     "nats": "^2.28.1",
-    "node-nats-streaming": "^0.3.2",
     "tsd": "^0.31.2"
   }
 }

--- a/src/nats-events/__tests__/nats-events.test.ts
+++ b/src/nats-events/__tests__/nats-events.test.ts
@@ -1,0 +1,144 @@
+import { JSONCodec } from "nats";
+import { Publisher } from "../publisher";
+import { Listener } from "../listener";
+import { Subjects } from "../subjects";
+import { EVENTS_STREAM_NAME, connectAndSetup } from "../setup";
+
+const codec = JSONCodec();
+
+interface TaskCreatedEvent {
+  subject: Subjects.TaskCreated;
+  data: { id: string; title: string };
+}
+
+class TaskCreatedPublisher extends Publisher<TaskCreatedEvent> {
+  subject: Subjects.TaskCreated = Subjects.TaskCreated;
+}
+
+class TaskCreatedListener extends Listener<TaskCreatedEvent> {
+  subject: Subjects.TaskCreated = Subjects.TaskCreated;
+  queueGroupName = "tasks-service";
+  onMessage = jest.fn();
+}
+
+/** Fake NatsConnection that records JetStream interactions. */
+function makeFakeNc() {
+  const publish = jest.fn().mockResolvedValue({ seq: 1, stream: "EVENTS" });
+  const consumerInfo = jest.fn();
+  const consumerAdd = jest.fn().mockResolvedValue({});
+  const consume = jest.fn().mockResolvedValue({
+    [Symbol.asyncIterator]: async function* () {
+      // Yield one fake message so the listener loop ticks once.
+      yield {
+        data: codec.encode({ id: "t1", title: "hello" }),
+        ack: jest.fn(),
+        nak: jest.fn(),
+        info: { stream: EVENTS_STREAM_NAME },
+      };
+    },
+  });
+  const consumerGet = jest.fn().mockResolvedValue({ consume });
+
+  const js = { publish };
+  const jsm = {
+    consumers: { info: consumerInfo, add: consumerAdd },
+  };
+  const consumers = { get: consumerGet };
+
+  const nc = {
+    jetstream: jest.fn(() => ({ ...js, consumers })),
+    jetstreamManager: jest.fn(async () => jsm),
+  };
+
+  return { nc, publish, consumerInfo, consumerAdd, consumerGet, consume };
+}
+
+describe("Publisher", () => {
+  it("publishes JSON-encoded data on its subject", async () => {
+    const { nc, publish } = makeFakeNc();
+    const p = new TaskCreatedPublisher(nc as never);
+
+    await p.publish({ id: "t1", title: "hello" });
+
+    expect(publish).toHaveBeenCalledTimes(1);
+    const [subject, payload] = publish.mock.calls[0];
+    expect(subject).toBe("task:created");
+    expect(JSON.parse(Buffer.from(payload).toString())).toEqual({
+      id: "t1",
+      title: "hello",
+    });
+  });
+});
+
+describe("Listener", () => {
+  it("creates a durable consumer when one doesn't exist", async () => {
+    const { nc, consumerInfo, consumerAdd } = makeFakeNc();
+    consumerInfo.mockRejectedValueOnce(new Error("not found"));
+
+    const l = new TaskCreatedListener(nc as never);
+    await l.listen();
+
+    expect(consumerAdd).toHaveBeenCalledTimes(1);
+    const [stream, cfg] = consumerAdd.mock.calls[0];
+    expect(stream).toBe(EVENTS_STREAM_NAME);
+    expect(cfg).toMatchObject({
+      durable_name: "tasks-service-task-created",
+      filter_subject: "task:created",
+      ack_policy: "explicit",
+      deliver_policy: "all",
+    });
+  });
+
+  it("reuses an existing consumer (idempotent)", async () => {
+    const { nc, consumerInfo, consumerAdd } = makeFakeNc();
+    consumerInfo.mockResolvedValueOnce({ name: "tasks-service--task-created" });
+
+    const l = new TaskCreatedListener(nc as never);
+    await l.listen();
+
+    expect(consumerAdd).not.toHaveBeenCalled();
+  });
+
+  it("parses JSON messages and invokes onMessage", async () => {
+    const { nc } = makeFakeNc();
+    const l = new TaskCreatedListener(nc as never);
+    await l.listen();
+
+    // The fake consume() yields one message synchronously when iterated; the
+    // listener spawns its consumption loop, so give the microtask queue a tick.
+    await new Promise((r) => setImmediate(r));
+
+    expect(l.onMessage).toHaveBeenCalledWith(
+      { id: "t1", title: "hello" },
+      expect.any(Object),
+    );
+  });
+
+  it("sanitises subject delimiters in durable consumer names", async () => {
+    class NestedListener extends Listener<{
+      subject: Subjects.OrganizationMemberRoleUpdated;
+      data: { id: string };
+    }> {
+      subject: Subjects.OrganizationMemberRoleUpdated =
+        Subjects.OrganizationMemberRoleUpdated;
+      queueGroupName = "auth-service";
+      onMessage = jest.fn();
+    }
+
+    const { nc, consumerInfo, consumerAdd } = makeFakeNc();
+    consumerInfo.mockRejectedValueOnce(new Error("not found"));
+
+    await new NestedListener(nc as never).listen();
+
+    const [, cfg] = consumerAdd.mock.calls[0];
+    expect(cfg.durable_name).not.toContain(":");
+    expect(cfg.durable_name).toMatch(/^[a-zA-Z0-9_-]+$/);
+  });
+});
+
+describe("connectAndSetup", () => {
+  it("is exported with the expected shape", () => {
+    expect(typeof connectAndSetup).toBe("function");
+    expect(EVENTS_STREAM_NAME).toBe("EVENTS");
+  });
+});

--- a/src/nats-events/index.ts
+++ b/src/nats-events/index.ts
@@ -2,4 +2,5 @@
 
 export * from "./listener";
 export * from "./publisher";
+export * from "./setup";
 export * from "./subjects";

--- a/src/nats-events/listener.ts
+++ b/src/nats-events/listener.ts
@@ -1,53 +1,84 @@
-import { Message, Stan } from "node-nats-streaming";
+import {
+  AckPolicy,
+  DeliverPolicy,
+  JsMsg,
+  JSONCodec,
+  NatsConnection,
+} from "nats";
 import { Subjects } from "./subjects";
+import { EVENTS_STREAM_NAME } from "./setup";
 
 interface Event {
   subject: Subjects;
-  data: any;
+  data: unknown;
 }
+
+const codec = JSONCodec();
+
+export type Message = JsMsg;
 
 export abstract class Listener<T extends Event> {
   abstract subject: T["subject"];
   abstract queueGroupName: string;
   abstract onMessage(data: T["data"], msg: Message): void;
 
-  private client: Stan;
+  private nc: NatsConnection;
 
   protected ackWait: number = 5 * 1000;
 
-  constructor(client: Stan) {
-    this.client = client;
+  constructor(nc: NatsConnection) {
+    this.nc = nc;
   }
 
-  subscriptionOptions() {
-    return this.client
-      .subscriptionOptions()
-      .setDeliverAllAvailable()
-      .setManualAckMode(true)
-      .setAckWait(this.ackWait)
-      .setDurableName(this.queueGroupName);
-  }
+  async listen(): Promise<void> {
+    const js = this.nc.jetstream();
+    const jsm = await this.nc.jetstreamManager();
 
-  listen() {
-    const subs = this.client.subscribe(
-      this.subject,
-      this.queueGroupName,
-      this.subscriptionOptions(),
+    const durable = sanitiseDurableName(
+      `${this.queueGroupName}--${this.subject}`,
     );
 
-    subs.on("message", (msg: Message) => {
-      console.log(`Msg received: ${this.subject} / ${this.queueGroupName}`);
+    try {
+      await jsm.consumers.info(EVENTS_STREAM_NAME, durable);
+    } catch {
+      await jsm.consumers.add(EVENTS_STREAM_NAME, {
+        durable_name: durable,
+        deliver_policy: DeliverPolicy.All,
+        ack_policy: AckPolicy.Explicit,
+        ack_wait: this.ackWait * 1_000_000, // ms → ns
+        filter_subject: this.subject,
+        max_deliver: -1,
+      });
+    }
 
-      const parsedData = this.parser(msg);
-      this.onMessage(parsedData, msg);
-    });
+    const consumer = await js.consumers.get(EVENTS_STREAM_NAME, durable);
+    const messages = await consumer.consume();
+
+    (async () => {
+      for await (const m of messages) {
+        try {
+          this.onMessage(this.parser(m), m);
+        } catch (err) {
+          // Don't ack on handler error — let JetStream redeliver up to max_deliver.
+          console.error(
+            `[Listener:${this.queueGroupName}] error on '${this.subject}':`,
+            err,
+          );
+        }
+      }
+    })();
   }
 
-  parser(msg: Message) {
-    const data = msg.getData();
-
-    return typeof data === "string"
-      ? JSON.parse(data)
-      : JSON.parse(data.toString("utf-8"));
+  parser(msg: Message): T["data"] {
+    return codec.decode(msg.data) as T["data"];
   }
+}
+
+// JetStream durable names must match /^[a-zA-Z0-9_-]+$/. Subjects use ':' as
+// the delimiter, so we replace it with '-' and length-cap to 64 chars.
+function sanitiseDurableName(raw: string): string {
+  return raw
+    .replace(/[^a-zA-Z0-9_-]+/g, "-")
+    .replace(/-+/g, "-")
+    .slice(0, 64);
 }

--- a/src/nats-events/publisher.ts
+++ b/src/nats-events/publisher.ts
@@ -1,85 +1,24 @@
-import { Stan } from "node-nats-streaming";
+import { JSONCodec, NatsConnection } from "nats";
 import { Subjects } from "./subjects";
-import { NatsConnection, Payload } from "nats";
 
-/**
- * An interface that defines the structure of an event.
- */
 interface Event {
   subject: Subjects;
-  data: any;
+  data: unknown;
 }
 
-/**
- * An abstract base class for publishing events to multiple communication channels.
- * @typeparam T - The event type that extends the Event interface.
- */
+const codec = JSONCodec();
+
 export abstract class Publisher<T extends Event> {
-  /**
-   * The subject of the event to be published.
-   */
   abstract subject: T["subject"];
 
-  /**
-   * The NATS Streaming client used for publishing to NATS.
-   */
-  private natsClient: Stan;
+  private nc: NatsConnection;
 
-  /**
-   * The WebSocket client used for publishing to WebSocket.
-   * This is optional and will only be used if provided.
-   */
-  private wsClient?: NatsConnection;
-
-  /**
-   * Creates a new Publisher instance.
-   * @param natsClient - The NATS Streaming client instance.
-   * @param wsClient - (Optional) The WebSocket client instance for WebSocket communication.
-   */
-  constructor(natsClient: Stan, wsClient?: NatsConnection) {
-    this.natsClient = natsClient;
-    this.wsClient = wsClient;
+  constructor(nc: NatsConnection) {
+    this.nc = nc;
   }
 
-  /**
-   * Publishes the event data to the NATS and optionally to the WebSocket channel.
-   * @param data - The event data to be published.
-   * @returns A Promise that resolves when the event is successfully published or rejects if there is an error.
-   */
   async publish(data: T["data"]): Promise<void> {
-    // Publish to NATS
-    await new Promise<void>((resolve, reject) => {
-      this.natsClient.publish(this.subject, JSON.stringify(data), (err) => {
-        if (err) {
-          console.error("Error publishing to NATS:", err);
-          reject(err);
-        } else {
-          console.log("(NATS) Event published to subject", this.subject);
-          resolve();
-        }
-      });
-    });
-
-    // Publish to WebSocket if client is provided
-    if (this.wsClient) {
-      try {
-        if (this.wsClient.isClosed()) {
-          console.log("(WS) WebSocket is closed. Reconnecting...");
-          // Add logic to handle reconnection if needed
-        }
-
-        // Publish the message
-        this.wsClient.publish(
-          this.subject,
-          Buffer.from(JSON.stringify(data)) as any,
-        );
-        console.log("(WS) Event published to subject", this.subject);
-
-        // Optionally, you can flush the message to ensure it's sent immediately
-        await this.wsClient.flush();
-      } catch (err) {
-        console.error("Error during WebSocket operation:", err);
-      }
-    }
+    const js = this.nc.jetstream();
+    await js.publish(this.subject, codec.encode(data));
   }
 }

--- a/src/nats-events/setup.ts
+++ b/src/nats-events/setup.ts
@@ -11,8 +11,12 @@ import {
 } from "nats";
 
 export const EVENTS_STREAM_NAME = "EVENTS";
-// `>` matches every subject — every Caytu event flows through this one stream.
-export const EVENTS_STREAM_SUBJECTS = [">"];
+// `*` matches any single-token subject. Caytu's event subjects use `:` as the
+// delimiter (e.g. `task:created`), which NATS treats as part of a single
+// token — so `*` captures all of them. Using `>` instead would also capture
+// JetStream's internal `$JS.>` control subjects and the server then requires
+// no_ack mode, which we don't want.
+export const EVENTS_STREAM_SUBJECTS = ["*"];
 
 export interface CaytuNatsClients {
   nc: NatsConnection;

--- a/src/nats-events/setup.ts
+++ b/src/nats-events/setup.ts
@@ -1,0 +1,69 @@
+import {
+  connect,
+  ConnectionOptions,
+  NatsConnection,
+  JetStreamClient,
+  AckPolicy,
+  DeliverPolicy,
+  RetentionPolicy,
+  StorageType,
+  StreamConfig,
+} from "nats";
+
+export const EVENTS_STREAM_NAME = "EVENTS";
+// `>` matches every subject — every Caytu event flows through this one stream.
+export const EVENTS_STREAM_SUBJECTS = [">"];
+
+export interface CaytuNatsClients {
+  nc: NatsConnection;
+  js: JetStreamClient;
+  close: () => Promise<void>;
+}
+
+export interface CaytuNatsConnectOptions {
+  servers: string | string[];
+  name: string;
+  extra?: Partial<ConnectionOptions>;
+  stream?: Partial<StreamConfig>;
+}
+
+/**
+ * Connect to NATS and ensure the EVENTS stream exists. Idempotent.
+ */
+export async function connectAndSetup(
+  opts: CaytuNatsConnectOptions,
+): Promise<CaytuNatsClients> {
+  const nc = await connect({
+    servers: opts.servers,
+    name: opts.name,
+    reconnect: true,
+    maxReconnectAttempts: -1,
+    reconnectTimeWait: 2_000,
+    ...(opts.extra ?? {}),
+  });
+
+  const jsm = await nc.jetstreamManager();
+  const desired: Partial<StreamConfig> = {
+    name: EVENTS_STREAM_NAME,
+    subjects: EVENTS_STREAM_SUBJECTS,
+    storage: StorageType.Memory,
+    retention: RetentionPolicy.Limits,
+    max_age: 24 * 60 * 60 * 1_000_000_000, // 24h in ns
+    max_msgs_per_subject: 10_000,
+    ...(opts.stream ?? {}),
+  };
+  try {
+    await jsm.streams.info(EVENTS_STREAM_NAME);
+    await jsm.streams.update(EVENTS_STREAM_NAME, desired);
+  } catch {
+    await jsm.streams.add(desired as StreamConfig);
+  }
+
+  return {
+    nc,
+    js: nc.jetstream(),
+    close: () => nc.drain(),
+  };
+}
+
+export { AckPolicy, DeliverPolicy, RetentionPolicy, StorageType };


### PR DESCRIPTION
Replaces node-nats-streaming with JetStream-backed nats client. Publisher/Listener API unchanged for subclasses (still declare subject + queueGroupName + onMessage); only the constructor argument changes from Stan to NatsConnection. New connectAndSetup() helper handles connection + stream creation. Tag v3.0.0-rc.1 was pushed alongside this branch to trigger CodeArtifact publish for end-to-end testing against url-shortener before promoting to 3.0.0.