### PR TITLE
ci: publish job checks out latest main, not trigger commit

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -126,9 +126,14 @@ jobs:
     needs: create-release
     runs-on: ubuntu-latest
     steps:
+      # Checkout latest main (not the trigger commit) so we pick up the
+      # version bump that create-release just pushed. Without ref: main,
+      # this job sees package.json at the pre-bump version and either
+      # publishes a stale prerelease or 409s on an already-published version.
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: main
       - name: Fetch tags
         run: git fetch --tags
 


### PR DESCRIPTION
create-release pushes a 'Bump version' commit before publish runs. The publish job was checking out the original trigger ref so it never saw the new version, which caused the 3.0.0 publish to 409 since the old 3.0.0-rc.2 had already been published. Fix is one line: checkout ref: main so publish always sees the bumped version.