### PR TITLE
License grant event, refunded payment status

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caytu/shared",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Shared Library for Caytu",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
@@ -21,6 +21,7 @@
     "./users/utils": "./build/users/utils/index.js",
     "./billings/models": "./build/billings/models/index.js",
     "./billings/events": "./build/billings/events/index.js",
+    "./licenses/events": "./build/licenses/events/index.js",
     "./billings/enums": "./build/billings/enums/index.js",
     "./tasks/models": "./build/tasks/models/index.js",
     "./tasks/events": "./build/tasks/events/index.js",
@@ -82,6 +83,9 @@
       ],
       "billings/models": [
         "build/billings/models/index.d.ts"
+      ],
+      "licenses/events": [
+        "build/licenses/events/index.d.ts"
       ],
       "billings/events": [
         "build/billings/events/index.d.ts"

--- a/src/billings/enums/payments.ts
+++ b/src/billings/enums/payments.ts
@@ -3,6 +3,12 @@ export enum PaymentStatus {
   Succeeded = "succeeded",
   Cancelled = "cancelled",
   Failed = "failed",
+  /**
+   * Money returned to the customer. A payment can be refunded in several
+   * partial steps, so this marks a payment refunded in full — how much came
+   * back overall is the sum of its refund records.
+   */
+  Refunded = "refunded",
 }
 
 export enum PaymentMethod {

--- a/src/licenses/events/index.ts
+++ b/src/licenses/events/index.ts
@@ -1,0 +1,4 @@
+// Objective:   Centralize the exports of the events types
+//              from the licenses/events folder
+
+export * from "./license-evt.types";

--- a/src/licenses/events/license-evt.types.ts
+++ b/src/licenses/events/license-evt.types.ts
@@ -1,0 +1,49 @@
+import { Subjects } from "../../nats-events/subjects";
+
+/**
+ * Billings asks for a device license to be minted for an organization.
+ *
+ * Published when a super-admin approves an Enterprise subscription request and
+ * grants a license with it. The licenses service listens and mints the signed
+ * token.
+ *
+ * The payload deliberately carries the subscription state the licenses service
+ * needs — plan type, expiry, entitled feature flags. Licenses otherwise reads
+ * that from billings over HTTP by forwarding the *caller's* JWT, and an event
+ * has no caller: it has no credential of its own to call back with. Carrying
+ * the state makes the event self-contained and keeps the two services from
+ * depending on each other at request time.
+ */
+export interface LicenseGrantRequestedEvent {
+  subject: Subjects.LicenseGrantRequested;
+  data: {
+    organizationId: string;
+    organizationName?: string;
+    subscriptionId: string;
+    /** Who approved it — the license is issued on their behalf. */
+    requestedById: string;
+    /** Days the license should run for; clamped to `subscriptionValidUntil`. */
+    requestedDays?: number;
+    /** Flags baked into the signed token. Defaults to the plan's. */
+    features?: string[];
+    /** Guard: licensing is an Enterprise entitlement. */
+    planType?: string;
+    planTitle?: string;
+    /** A license must never outlive the subscription backing it. */
+    subscriptionValidUntil?: string | null;
+    version: number;
+  };
+}
+
+/** A signed device license was minted. */
+export interface LicenseIssuedEvent {
+  subject: Subjects.LicenseIssued;
+  data: {
+    organizationId: string;
+    licenseId: string;
+    subscriptionId?: string;
+    features: string[];
+    notAfter: number;
+    version: number;
+  };
+}

--- a/src/nats-events/subjects.ts
+++ b/src/nats-events/subjects.ts
@@ -201,6 +201,11 @@ export enum Subjects {
   BillingPaymentMethodCreated = "billing:payment:method:create",
   BillingPaymentMethodUpdated = "billing:payment:method:update",
 
+  // License
+  /** A subscription approval entitles an org to a signed device license. */
+  LicenseGrantRequested = "license:grant:requested",
+  LicenseIssued = "license:issued",
+
   // Subscription
   SubscriptionCreated = "subscription:created",
   SubscriptionUpdated = "subscription:updated",


### PR DESCRIPTION
Adds what the Caytu-Infra subscription and licensing work needs from shared.

`license:grant:requested` lets billings ask the licenses service to mint a signed device license when a super-admin approves an Enterprise subscription and grants one with it. The payload deliberately carries the subscription state licenses needs — plan type, expiry, entitled feature flags — because licenses reads that from billings by forwarding the caller's JWT today, and an event has no caller and no service credential of its own. Carrying the state keeps the event self-contained and stops the two services depending on each other at request time. `license:issued` is published back once the token is minted.

`PaymentStatus.Refunded` is the other half: refunds exist in billings now, and the enum had no way to say a payment had been refunded.

Minor version — both are additive.