### PR TITLE
Split roles into two axes, and share the migration runner

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ export * from "./middlewares/robots/authorize-robot";
 
 export * from "./types/utils";
 
+export * from "./migrations";
+
 export * from "./utils";
 export * from "./utils/encryptor";
 export * from "./utils/cookies";

--- a/src/middlewares/auth/__tests__/role-base-access.test.ts
+++ b/src/middlewares/auth/__tests__/role-base-access.test.ts
@@ -1,0 +1,165 @@
+import { RbaUserACL } from "../role-base-access";
+import { UserRole, splitRoles } from "../../../types/utils";
+
+const user = (
+  platform: UserRole[],
+  org?: UserRole[],
+): Record<string, unknown> => ({
+  id: "u1",
+  roles: platform,
+  ...(org
+    ? { rolesInCurrentOrganization: { organizationId: "o1", roles: org } }
+    : {}),
+});
+
+/**
+ * express-async-handler hands a thrown ForbiddenErr to `next(err)` rather than
+ * letting it escape, so a bare `next` spy would score a denial as a pass.
+ */
+const run = async (guard: any, currentUser: unknown): Promise<boolean> => {
+  const req: any = { currentUser };
+  let passed = false;
+  await guard(req, {} as any, (err?: unknown) => {
+    passed = !err;
+  });
+  return passed;
+};
+
+describe("splitRoles", () => {
+  it("partitions a mixed array and keeps unknown values", () => {
+    expect(
+      splitRoles([
+        UserRole.All,
+        UserRole.SuperAdmin,
+        UserRole.All,
+        "bogus" as UserRole,
+      ]),
+    ).toEqual({
+      primary: [UserRole.SuperAdmin],
+      permissions: [UserRole.All],
+      unknown: ["bogus"],
+    });
+  });
+});
+
+describe("isSuperAdmin", () => {
+  it("passes a platform super-admin", async () => {
+    expect(
+      await run(RbaUserACL.isSuperAdmin, user([UserRole.SuperAdmin])),
+    ).toBe(true);
+  });
+
+  it("does NOT pass `all` — a member permission is not an identity", async () => {
+    expect(await run(RbaUserACL.isSuperAdmin, user([UserRole.All]))).toBe(
+      false,
+    );
+  });
+
+  // The escalation this whole change exists to close: the schema permitted
+  // `super-admin` inside an organization's array, and the old union read granted
+  // platform god-mode from it.
+  it("does NOT pass super-admin held only inside an organization", async () => {
+    expect(
+      await run(
+        RbaUserACL.isSuperAdmin,
+        user([UserRole.Customer], [UserRole.SuperAdmin]),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("member permissions", () => {
+  it("grants a verb from the org array", async () => {
+    expect(
+      await run(
+        RbaUserACL.canCreate,
+        user([UserRole.Customer], [UserRole.Create]),
+      ),
+    ).toBe(true);
+  });
+
+  it("treats `all` in the org array as every verb", async () => {
+    const member = user([UserRole.Customer], [UserRole.All]);
+    expect(await run(RbaUserACL.canCreate, member)).toBe(true);
+    expect(await run(RbaUserACL.canEdit, member)).toBe(true);
+    expect(await run(RbaUserACL.canDelete, member)).toBe(true);
+  });
+
+  it("does not grant a verb the member was never given", async () => {
+    expect(
+      await run(
+        RbaUserACL.canDelete,
+        user([UserRole.Customer], [UserRole.Create]),
+      ),
+    ).toBe(false);
+  });
+
+  it("lets identity imply verbs for admins and super-admins", async () => {
+    expect(await run(RbaUserACL.canDelete, user([UserRole.SuperAdmin]))).toBe(
+      true,
+    );
+    expect(
+      await run(
+        RbaUserACL.canDelete,
+        user([UserRole.Customer], [UserRole.Admin]),
+      ),
+    ).toBe(true);
+  });
+
+  describe("STRICT_ROLE_AXES", () => {
+    const strict = process.env.STRICT_ROLE_AXES;
+    afterEach(() => {
+      process.env.STRICT_ROLE_AXES = strict;
+    });
+
+    it("honours a platform-array permission while unmigrated data exists", async () => {
+      delete process.env.STRICT_ROLE_AXES;
+      expect(
+        await run(
+          RbaUserACL.canCreate,
+          user([UserRole.Customer, UserRole.All]),
+        ),
+      ).toBe(true);
+    });
+
+    it("stops honouring it once the environment is migrated", async () => {
+      process.env.STRICT_ROLE_AXES = "true";
+      expect(
+        await run(
+          RbaUserACL.canCreate,
+          user([UserRole.Customer, UserRole.All]),
+        ),
+      ).toBe(false);
+    });
+
+    it("leaves a properly-partitioned member unaffected either way", async () => {
+      const member = user([UserRole.Customer], [UserRole.All]);
+      process.env.STRICT_ROLE_AXES = "true";
+      expect(await run(RbaUserACL.canCreate, member)).toBe(true);
+      delete process.env.STRICT_ROLE_AXES;
+      expect(await run(RbaUserACL.canCreate, member)).toBe(true);
+    });
+  });
+});
+
+describe("identity guards", () => {
+  it("accepts an org-scoped admin as admin", async () => {
+    expect(
+      await run(
+        RbaUserACL.isAdmin,
+        user([UserRole.Customer], [UserRole.Admin]),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a bare customer as admin", async () => {
+    expect(await run(RbaUserACL.isAdmin, user([UserRole.Customer]))).toBe(
+      false,
+    );
+  });
+
+  it("rejects a user with no roles at all", async () => {
+    expect(await run(RbaUserACL.canReadOnly, user([]))).toBe(false);
+    expect(await run(RbaUserACL.isCustomer, user([]))).toBe(false);
+  });
+});

--- a/src/middlewares/auth/role-base-access.ts
+++ b/src/middlewares/auth/role-base-access.ts
@@ -1,34 +1,103 @@
 import asyncHandler from "express-async-handler";
 import { NextFunction, Request, Response } from "express";
 import { ForbiddenErr } from "../../errors/forbidden";
-import { UserRole } from "../../types/utils";
+import {
+  PrimaryRole,
+  UserPermission,
+  UserRole,
+  isUserPermission,
+} from "../../types/utils";
+
+/**
+ * Roles come in two axes, and they must not be read against each other.
+ *
+ * A *primary role* says who someone is. It exists per scope: a user has a
+ * primary role on the platform (`roles`) and one in each organization they
+ * belong to (`rolesInCurrentOrganization.roles`). `SuperAdmin` is the exception
+ * — it is platform-only, and a `super-admin` value sitting in an organization's
+ * array must grant nothing, or any organization could mint a platform
+ * administrator.
+ *
+ * A *member permission* (`create`, `update`, `delete`, `readOnly`, and the `all`
+ * wildcard) says what a member may do inside one organization. It is only ever
+ * read from that organization's array. `all` has never meant super-admin; it
+ * means "every verb, for this member, in this organization".
+ *
+ * Until the role-partition migration has run, live data still carries
+ * permissions in the platform array. Reading strictly on day one would silently
+ * revoke verbs from those users, so permission reads fall back to the platform
+ * array and warn. Set STRICT_ROLE_AXES=true once an environment's data has been
+ * migrated, to drop the fallback. See CAYTU/Caytu-Infra#920.
+ */
+const strictAxes = () => process.env.STRICT_ROLE_AXES === "true";
+
+const platformRolesOf = (user: any): UserRole[] => user?.roles ?? [];
+
+const orgRolesOf = (user: any): UserRole[] =>
+  user?.rolesInCurrentOrganization?.roles ?? [];
+
+/**
+ * Identity check. `SuperAdmin` is honoured only from the platform array; every
+ * other primary role may be held either on the platform or in the current
+ * organization.
+ */
+const hasPrimaryRole = (user: any, roles: PrimaryRole[]): boolean => {
+  const platform = platformRolesOf(user);
+  const org = orgRolesOf(user);
+
+  return roles.some((role) =>
+    role === UserRole.SuperAdmin
+      ? platform.includes(role)
+      : platform.includes(role) || org.includes(role),
+  );
+};
+
+/**
+ * Permission check, satisfied by any of:
+ *   - a super-admin on the platform, or an admin here — identity implies verbs;
+ *   - the `all` wildcard in this organization;
+ *   - the specific permission in this organization.
+ *
+ * In compat mode the last two also accept the permission from the platform
+ * array, which is where unmigrated data still keeps it.
+ */
+const hasPermission = (user: any, permissions: UserPermission[]): boolean => {
+  if (hasPrimaryRole(user, [UserRole.SuperAdmin, UserRole.Admin])) return true;
+
+  const granted: UserRole[] = [...permissions, UserRole.All];
+  const org = orgRolesOf(user);
+  if (granted.some((permission) => org.includes(permission))) return true;
+
+  if (strictAxes()) return false;
+
+  const legacy = platformRolesOf(user).filter(isUserPermission);
+  const matched = granted.some((permission) =>
+    legacy.includes(permission as UserPermission),
+  );
+
+  if (matched) {
+    console.warn(
+      `[rbac] user ${user?.id ?? "?"} granted ${permissions.join("/")} from a ` +
+        `platform-array permission (${legacy.join(",")}). Member permissions belong ` +
+        `in rolesInOrganization — run the role-partition migration, then set ` +
+        `STRICT_ROLE_AXES=true.`,
+    );
+  }
+
+  return matched;
+};
 
 /**
  * Role Based Access Control (RBAC) middleware for user access control.
  */
 const RbaUserACL = {
-  /**
-   * Middleware that allows access for users with UserRole.Create, UserRole.All, or UserRole.Admin roles.
-   * Throws a ForbiddenErr if access is denied.
-   */
+  hasPrimaryRole,
+  hasPermission,
 
-  // Helper function to check platform and organization level roles
-  hasRequiredRole: (user: any, roles: UserRole[]) => {
-    const platformRoles = user?.roles || [];
-    const orgRoles = user?.rolesInCurrentOrganization?.roles || [];
-    return roles.some(
-      (role) => platformRoles.includes(role) || orgRoles.includes(role),
-    );
-  },
+  /** Allows super-admins, admins, and members holding `create` (or `all`). */
   canCreate: asyncHandler(
     async (req: Request, res: Response, next: NextFunction) => {
-      if (
-        RbaUserACL.hasRequiredRole(req.currentUser, [
-          UserRole.Create,
-          UserRole.All,
-          UserRole.SuperAdmin,
-        ])
-      ) {
+      if (hasPermission(req.currentUser, [UserRole.Create])) {
         next();
       } else {
         throw new ForbiddenErr(
@@ -38,19 +107,10 @@ const RbaUserACL = {
     },
   ),
 
-  /**
-   * Middleware that allows access for users with UserRole.Update, UserRole.All, or UserRole.Admin roles.
-   * Throws a ForbiddenErr if access is denied.
-   */
+  /** Allows super-admins, admins, and members holding `update` (or `all`). */
   canEdit: asyncHandler(
     async (req: Request, res: Response, next: NextFunction) => {
-      if (
-        RbaUserACL.hasRequiredRole(req.currentUser, [
-          UserRole.All,
-          UserRole.Update,
-          UserRole.SuperAdmin,
-        ])
-      ) {
+      if (hasPermission(req.currentUser, [UserRole.Update])) {
         next();
       } else {
         throw new ForbiddenErr(
@@ -60,19 +120,10 @@ const RbaUserACL = {
     },
   ),
 
-  /**
-   * Middleware that allows access for users with UserRole.Delete, UserRole.All, or UserRole.Admin roles.
-   * Throws a ForbiddenErr if access is denied.
-   */
+  /** Allows super-admins, admins, and members holding `delete` (or `all`). */
   canDelete: asyncHandler(
     async (req: Request, res: Response, next: NextFunction) => {
-      if (
-        RbaUserACL.hasRequiredRole(req.currentUser, [
-          UserRole.All,
-          UserRole.Delete,
-          UserRole.SuperAdmin,
-        ])
-      ) {
+      if (hasPermission(req.currentUser, [UserRole.Delete])) {
         next();
       } else {
         throw new ForbiddenErr(
@@ -83,24 +134,23 @@ const RbaUserACL = {
   ),
 
   /**
-   * Middleware that allows read-only access for users with UserRole.ReadOnly, UserRole.All, or UserRole.Admin roles.
-   * Throws a ForbiddenErr if access is denied.
+   * Allows anyone who is somebody. Every primary role can read, so this is an
+   * identity check, with an escape hatch for a member whose only grant is
+   * `readOnly` (or `all`).
    */
   canReadOnly: asyncHandler(
     async (req: Request, res: Response, next: NextFunction) => {
-      if (
-        RbaUserACL.hasRequiredRole(req.currentUser, [
-          UserRole.ReadOnly,
-          UserRole.All,
-          UserRole.Admin,
-          UserRole.Customer,
-          UserRole.Operator,
-          UserRole.Developer,
-          UserRole.Robot,
-          UserRole.Invited,
-          UserRole.SuperAdmin,
-        ])
-      ) {
+      const isSomebody = hasPrimaryRole(req.currentUser, [
+        UserRole.Invited,
+        UserRole.Robot,
+        UserRole.Customer,
+        UserRole.Developer,
+        UserRole.Operator,
+        UserRole.Admin,
+        UserRole.SuperAdmin,
+      ]);
+
+      if (isSomebody || hasPermission(req.currentUser, [UserRole.ReadOnly])) {
         next();
       } else {
         throw new ForbiddenErr(
@@ -110,14 +160,11 @@ const RbaUserACL = {
     },
   ),
 
-  /**
-   * Middleware that allows access for users with UserRole.Customer, UserRole.Admin, UserRole.All, or UserRole.Operator roles.
-   * Throws a ForbiddenErr if access is denied.
-   */
+  /** Allows customers and anyone above them. */
   isCustomer: asyncHandler(
     async (req: Request, res: Response, next: NextFunction) => {
       if (
-        RbaUserACL.hasRequiredRole(req.currentUser, [
+        hasPrimaryRole(req.currentUser, [
           UserRole.Customer,
           UserRole.Admin,
           UserRole.Operator,
@@ -134,14 +181,11 @@ const RbaUserACL = {
     },
   ),
 
-  /**
-   * Middleware that allows access for users with UserRole.Operator, UserRole.Admin, or UserRole.All roles.
-   * Throws a ForbiddenErr if access is denied.
-   */
+  /** Allows operators, admins and super-admins. */
   isOperator: asyncHandler(
     async (req: Request, res: Response, next: NextFunction) => {
       if (
-        RbaUserACL.hasRequiredRole(req.currentUser, [
+        hasPrimaryRole(req.currentUser, [
           UserRole.Admin,
           UserRole.Operator,
           UserRole.SuperAdmin,
@@ -156,17 +200,11 @@ const RbaUserACL = {
     },
   ),
 
-  /**
-   * Middleware that allows access for users with UserRole.Admin or UserRole.All roles.
-   * Throws a ForbiddenErr if access is denied.
-   */
+  /** Allows admins and super-admins. */
   isAdmin: asyncHandler(
     async (req: Request, res: Response, next: NextFunction) => {
       if (
-        RbaUserACL.hasRequiredRole(req.currentUser, [
-          UserRole.Admin,
-          UserRole.SuperAdmin,
-        ])
+        hasPrimaryRole(req.currentUser, [UserRole.Admin, UserRole.SuperAdmin])
       ) {
         next();
       } else {
@@ -178,12 +216,12 @@ const RbaUserACL = {
   ),
 
   /**
-   * Middleware that allows access for users with UserRole.SuperAdmin or UserRole.All roles.
-   * Throws a ForbiddenErr if access is denied.
+   * Allows super-admins only, and only by virtue of the platform array — a
+   * `super-admin` value inside an organization's roles grants nothing here.
    */
   isSuperAdmin: asyncHandler(
     async (req: Request, res: Response, next: NextFunction) => {
-      if (RbaUserACL.hasRequiredRole(req.currentUser, [UserRole.SuperAdmin])) {
+      if (hasPrimaryRole(req.currentUser, [UserRole.SuperAdmin])) {
         next();
       } else {
         throw new ForbiddenErr(
@@ -193,14 +231,11 @@ const RbaUserACL = {
     },
   ),
 
-  /**
-   * Middleware that allows access for users with UserRole.Developer or UserRole.All roles.
-   * Throws a ForbiddenErr if access is denied.
-   */
+  /** Allows developers and super-admins. */
   isDeveloper: asyncHandler(
     async (req: Request, res: Response, next: NextFunction) => {
       if (
-        RbaUserACL.hasRequiredRole(req.currentUser, [
+        hasPrimaryRole(req.currentUser, [
           UserRole.Developer,
           UserRole.SuperAdmin,
         ])
@@ -214,17 +249,11 @@ const RbaUserACL = {
     },
   ),
 
-  /**
-   * Middleware that allows access for users with UserRole.Robot.
-   * Throws a ForbiddenErr if access is denied.
-   */
+  /** Allows robot accounts and super-admins. */
   isRobot: asyncHandler(
     async (req: Request, res: Response, next: NextFunction) => {
       if (
-        RbaUserACL.hasRequiredRole(req.currentUser, [
-          UserRole.Robot,
-          UserRole.SuperAdmin,
-        ])
+        hasPrimaryRole(req.currentUser, [UserRole.Robot, UserRole.SuperAdmin])
       ) {
         next();
       } else {

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./ledger";
+export * from "./runner";

--- a/src/migrations/ledger.ts
+++ b/src/migrations/ledger.ts
@@ -1,0 +1,40 @@
+import mongoose, { Model, Document } from "mongoose";
+
+/**
+ * A record that a migration ran, so it does not run twice.
+ *
+ * Migrations used to live as loose scripts that nothing invoked and nothing
+ * recorded — you could not tell whether one had already been applied to an
+ * environment, let alone which. Data fixes are rarely idempotent by luck, so
+ * "did this already run against prod?" is a question that needs a real answer.
+ */
+export interface MigrationDoc extends Document {
+  name: string;
+  appliedAt: Date;
+  /** Whatever the migration reported — counts, ids, skipped rows. */
+  result?: Record<string, unknown>;
+  /** Wall time, so a slow one is visible next run. */
+  durationMs?: number;
+}
+
+const migrationSchema = new mongoose.Schema<MigrationDoc>(
+  {
+    name: { type: String, required: true, unique: true },
+    appliedAt: { type: Date, default: Date.now },
+    result: { type: mongoose.Schema.Types.Mixed },
+    durationMs: { type: Number },
+  },
+  { collection: "migrations" },
+);
+
+/**
+ * Reuse the model if the host service already registered one under this name.
+ * billings defined its own `Migration` model before this moved into the package,
+ * and registering a second one would throw OverwriteModelError on import.
+ */
+export const MigrationLedger: Model<MigrationDoc> =
+  (mongoose.models.Migration as Model<MigrationDoc>) ??
+  mongoose.model<MigrationDoc, Model<MigrationDoc>>(
+    "Migration",
+    migrationSchema,
+  );

--- a/src/migrations/runner.ts
+++ b/src/migrations/runner.ts
@@ -1,0 +1,180 @@
+/**
+ * The migration runner, shared by every service.
+ *
+ *   yarn migrate list
+ *   yarn migrate status
+ *   yarn migrate run <name>            # dry run — reports, writes nothing
+ *   yarn migrate run <name> --apply    # actually writes
+ *
+ * Dry run is the default on purpose. These are data fixes pointed at real
+ * customers, and the scripts this replaced had no preview, no record of having
+ * run, and no way to invoke them at all.
+ *
+ * A service wires it up with a one-liner:
+ *
+ *   import { runMigrationCli } from "@caytu/shared";
+ *   import { MIGRATIONS } from "../models/migrations/registry";
+ *   runMigrationCli(MIGRATIONS);
+ *
+ * Migrations must never run on boot. A boot-time data fix re-scans the
+ * collection on every restart, cannot be previewed, and reaches production the
+ * moment an image rolls. See CAYTU/Caytu-Infra#920.
+ */
+
+import mongoose from "mongoose";
+import { MigrationLedger } from "./ledger";
+import { Migration, findMigration } from "./types";
+
+const RESET = "\x1b[0m";
+const BOLD = "\x1b[1m";
+const DIM = "\x1b[2m";
+const RED = "\x1b[31m";
+const GREEN = "\x1b[32m";
+const YELLOW = "\x1b[33m";
+
+const line = (msg = "") => console.log(msg);
+
+async function connect() {
+  const uri = process.env.MONGO_URI;
+  if (!uri) {
+    line(`${RED}MONGO_URI is not set${RESET}`);
+    process.exit(1);
+  }
+  await mongoose.connect(uri);
+  // The database is the thing you are about to change — say which one.
+  line(`${DIM}connected to ${mongoose.connection.name}${RESET}`);
+}
+
+async function cmdList(migrations: Migration[]) {
+  const applied = await MigrationLedger.find().lean();
+  const appliedAt = new Map(applied.map((a) => [a.name, a.appliedAt]));
+
+  line(`${BOLD}Migrations${RESET}`);
+  line();
+  for (const m of migrations) {
+    const at = appliedAt.get(m.name);
+    const state = at
+      ? `${GREEN}applied${RESET} ${DIM}${new Date(at).toISOString().slice(0, 10)}${RESET}`
+      : `${YELLOW}pending${RESET}`;
+    const preview = m.dryRun ? "" : ` ${DIM}(no dry run)${RESET}`;
+    line(`  ${BOLD}${m.name}${RESET}  ${state}${preview}`);
+    line(`    ${DIM}${m.description}${RESET}`);
+  }
+  line();
+}
+
+async function cmdStatus() {
+  const applied = await MigrationLedger.find().sort({ appliedAt: 1 }).lean();
+  if (applied.length === 0) {
+    line(`${YELLOW}No migration has been applied to this database.${RESET}`);
+    return;
+  }
+  line(`${BOLD}Applied${RESET}`);
+  for (const a of applied) {
+    line(
+      `  ${a.name} ${DIM}${new Date(a.appliedAt).toISOString()} (${a.durationMs ?? "?"}ms)${RESET}`,
+    );
+    if (a.result) line(`    ${DIM}${JSON.stringify(a.result)}${RESET}`);
+  }
+}
+
+async function cmdRun(
+  migrations: Migration[],
+  name: string,
+  apply: boolean,
+  force: boolean,
+) {
+  const migration = findMigration(migrations, name);
+  if (!migration) {
+    line(`${RED}No migration named "${name}".${RESET} Try: yarn migrate list`);
+    process.exit(1);
+  }
+
+  const already = await MigrationLedger.findOne({ name });
+  if (already && apply && !force) {
+    line(
+      `${YELLOW}"${name}" was already applied on ${new Date(
+        already.appliedAt,
+      ).toISOString()}.${RESET}`,
+    );
+    line(`Re-run it with --force if that is really what you want.`);
+    process.exit(1);
+  }
+
+  if (!apply) {
+    if (!migration.dryRun) {
+      // Silence here would read as "nothing to do", which is a lie.
+      line(
+        `${YELLOW}"${name}" has no dry run.${RESET} It cannot preview its changes.`,
+      );
+      line(`Run it for real with --apply, or add a dryRun() to the migration.`);
+      process.exit(1);
+    }
+    line(
+      `${BOLD}Dry run:${RESET} ${name} ${DIM}(nothing will be written)${RESET}`,
+    );
+    const result = await migration.dryRun();
+    line(JSON.stringify(result, null, 2));
+    line();
+    line(`${DIM}Re-run with --apply to write these changes.${RESET}`);
+    return;
+  }
+
+  line(`${BOLD}Applying:${RESET} ${name}`);
+  const started = Date.now();
+  const result = await migration.run();
+  const durationMs = Date.now() - started;
+
+  await MigrationLedger.findOneAndUpdate(
+    { name },
+    { name, appliedAt: new Date(), result, durationMs },
+    { upsert: true },
+  );
+
+  line(`${GREEN}Applied${RESET} ${DIM}in ${durationMs}ms${RESET}`);
+  line(JSON.stringify(result, null, 2));
+}
+
+/**
+ * Parse argv, run the requested command against `migrations`, and exit. Intended
+ * to be the entire body of a service's `src/scripts/migrate.ts`.
+ */
+export async function runMigrationCli(migrations: Migration[]): Promise<void> {
+  // This warning is not the operator's problem and it buries the report.
+  mongoose.set("strictQuery", true);
+
+  const [, , command, ...rest] = process.argv;
+  const args = rest.filter((a) => !a.startsWith("--"));
+  const apply = rest.includes("--apply");
+  const force = rest.includes("--force");
+
+  try {
+    await connect();
+
+    try {
+      switch (command) {
+        case "list":
+          await cmdList(migrations);
+          break;
+        case "status":
+          await cmdStatus();
+          break;
+        case "run":
+          if (!args[0]) {
+            line(`${RED}usage: yarn migrate run <name> [--apply]${RESET}`);
+            process.exit(1);
+          }
+          await cmdRun(migrations, args[0], apply, force);
+          break;
+        default:
+          line("usage: yarn migrate list | status | run <name> [--apply]");
+          process.exit(1);
+      }
+    } finally {
+      await mongoose.disconnect();
+    }
+  } catch (err: any) {
+    line(`${RED}Migration failed:${RESET} ${err?.message ?? err}`);
+    process.exit(1);
+  }
+}

--- a/src/migrations/types.ts
+++ b/src/migrations/types.ts
@@ -1,0 +1,21 @@
+export interface MigrationResult {
+  [key: string]: unknown;
+}
+
+export interface Migration {
+  name: string;
+  description: string;
+  /** Apply the change. */
+  run: () => Promise<MigrationResult>;
+  /**
+   * Report what `run` would do, without writing. Absent means this migration
+   * predates dry-run support — the runner refuses to preview it rather than
+   * print nothing and let that read as "no changes".
+   */
+  dryRun?: () => Promise<MigrationResult>;
+}
+
+export const findMigration = (
+  migrations: Migration[],
+  name: string,
+): Migration | undefined => migrations.find((m) => m.name === name);

--- a/src/types/utils/index.ts
+++ b/src/types/utils/index.ts
@@ -47,22 +47,80 @@ export enum UserRole {
   All = "all",
 }
 
+/**
+ * Who a user *is*. Exactly one of these is meaningful per scope: a user has a
+ * primary role on the platform, and a primary role in each organization they
+ * belong to.
+ *
+ * `SuperAdmin` is platform-only. It is not an organization role, and a value of
+ * `super-admin` inside an organization's role array grants nothing — see
+ * `RbaUserACL.hasPrimaryRole`.
+ */
 export const PrimaryRoles = [
   UserRole.Invited,
+  UserRole.Robot,
   UserRole.Customer,
   UserRole.Developer,
   UserRole.Operator,
   UserRole.Admin,
   UserRole.SuperAdmin,
-];
+] as const;
 
+/**
+ * What a member may *do* inside one organization. These are member permissions:
+ * they are only ever read from a user's roles in an organization, never from
+ * their platform roles. `All` is the wildcard over the other four — it means
+ * "every verb, for this member, in this organization". It has never meant
+ * super-admin.
+ */
 export const UserPermissions = [
   UserRole.All,
   UserRole.ReadOnly,
   UserRole.Create,
   UserRole.Delete,
   UserRole.Update,
-];
+] as const;
+
+/** A role that says who someone is. */
+export type PrimaryRole = (typeof PrimaryRoles)[number];
+
+/** A permission that says what a member may do in an organization. */
+export type UserPermission = (typeof UserPermissions)[number];
+
+export const isPrimaryRole = (role: UserRole): role is PrimaryRole =>
+  (PrimaryRoles as readonly UserRole[]).includes(role);
+
+export const isUserPermission = (role: UserRole): role is UserPermission =>
+  (UserPermissions as readonly UserRole[]).includes(role);
+
+/**
+ * Splits a mixed role array into the two axes. Values belonging to neither list
+ * are returned in `unknown` rather than silently dropped, so callers (the role
+ * partition migration, in particular) can report them instead of losing them.
+ */
+export const splitRoles = (
+  roles: UserRole[] = [],
+): {
+  primary: PrimaryRole[];
+  permissions: UserPermission[];
+  unknown: string[];
+} => {
+  const primary: PrimaryRole[] = [];
+  const permissions: UserPermission[] = [];
+  const unknown: string[] = [];
+
+  for (const role of roles) {
+    if (isPrimaryRole(role)) primary.push(role);
+    else if (isUserPermission(role)) permissions.push(role);
+    else unknown.push(role as string);
+  }
+
+  return {
+    primary: [...new Set(primary)],
+    permissions: [...new Set(permissions)],
+    unknown: [...new Set(unknown)],
+  };
+};
 
 /**
  * @description

--- a/src/users/utils/user-roles.ts
+++ b/src/users/utils/user-roles.ts
@@ -1,45 +1,19 @@
 /**
- * Enumerates the possible roles for users.
+ * This module used to carry a second, hand-maintained copy of `UserRole`,
+ * `PrimaryRoles` and `UserPermissions`. `utils/encryptor` typed the JWT payload
+ * against that copy while the RBAC guards used the one in `types/utils`, so the
+ * two could drift apart while still comparing equal at runtime, as string enums
+ * do.
+ *
+ * `types/utils` is the single source of truth. This re-export keeps existing
+ * importers working.
  */
-export enum UserRole {
-  Invited = "invited",
-  /** This is the most basic role that any user that creates an account through the API will have. This role is for the robot. */
-  Robot = "robot",
-  /** Basic operations are allowed: Read & Create Task. */
-  Customer = "customer",
-  /** This role combines both the customer and the operator roles. */
-  Operator = "operator",
-  /** Not only does it encapsulate the roles of customer and operator. */
-  Admin = "admin",
-  /** Super Admin role with extended privileges. */
-  SuperAdmin = "super-admin",
-  /** Allows users to delete resources. */
-  Delete = "delete",
-  /** Allows users to create resources. */
-  Create = "create",
-  /** Allows users to update resources. */
-  Update = "update",
-  /** Provides read-only access to resources. */
-  ReadOnly = "readOnly",
-  /** Role for developers with special privileges. */
-  Developer = "developer",
-  /** Special role granting all permissions. */
-  All = "all",
-}
-
-export const PrimaryRoles = [
-  UserRole.Invited,
-  UserRole.Customer,
-  UserRole.Developer,
-  UserRole.Operator,
-  UserRole.Admin,
-  UserRole.SuperAdmin,
-];
-
-export const UserPermissions = [
-  UserRole.All,
-  UserRole.ReadOnly,
-  UserRole.Create,
-  UserRole.Delete,
-  UserRole.Update,
-];
+export {
+  UserRole,
+  PrimaryRoles,
+  UserPermissions,
+  isPrimaryRole,
+  isUserPermission,
+  splitRoles,
+} from "../../types/utils";
+export type { PrimaryRole, UserPermission } from "../../types/utils";


### PR DESCRIPTION
Roles were one flat enum doing two jobs. A primary role says who someone is; a member permission (create/update/delete/readOnly, and the `all` wildcard) says what a member may do inside one organization. The package already declared both lists but nothing read them apart, and `hasRequiredRole` unioned the platform and org arrays — so a `super-admin` value sitting in an org's roles granted platform god-mode, and member permissions were honoured from the platform array. Super-admin is now read only from the platform array, and permissions only from the org array.

Permission reads fall back to the platform array and warn until the data is partitioned, because reading strictly on day one would silently revoke verbs from every user whose `all` still lives there. Set `STRICT_ROLE_AXES=true` per environment once its migration has run.

Also folds the migration runner, ledger and `Migration` type out of billings and into the package, so a service ships only a registry, and collapses the duplicate `UserRole` enum — the JWT payload was typed against one copy and the guards against the other. Groundwork for CAYTU/Caytu-Infra#920.