### PR TITLE
Make the error handler legible

### DIFF
--- a/src/middlewares/errors/__tests__/handler.test.ts
+++ b/src/middlewares/errors/__tests__/handler.test.ts
@@ -1,0 +1,86 @@
+import { errorHandler } from "../handler";
+import { CustomErr } from "../../../errors/custom";
+
+class TestErr extends CustomErr {
+  statusCode = 418;
+  constructor() {
+    super("teapot");
+    Object.setPrototypeOf(this, TestErr.prototype);
+  }
+  serializeErrors() {
+    return [{ message: "teapot" }];
+  }
+}
+
+const mockRes = () => {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.send = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+const req: any = { method: "POST", originalUrl: "/api/auth/login" };
+const next = jest.fn();
+
+describe("errorHandler", () => {
+  beforeEach(() => jest.spyOn(console, "error").mockImplementation(() => {}));
+  afterEach(() => jest.restoreAllMocks());
+
+  it("passes a CustomErr through with its own status", async () => {
+    const res = mockRes();
+    await errorHandler(new TestErr(), req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(418);
+    expect(res.send).toHaveBeenCalledWith({ errors: [{ message: "teapot" }] });
+  });
+
+  // The bug this fixes: a schema rejection surfaced as "Something went wrong".
+  it("surfaces the failing fields of a ValidationError", async () => {
+    const err = {
+      name: "ValidationError",
+      errors: {
+        "roles.0": {
+          path: "roles.0",
+          message: "`all` is not a valid enum value for path `roles.0`.",
+        },
+      },
+    };
+    const res = mockRes();
+
+    await errorHandler(err as any, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith({
+      errors: [
+        {
+          message: "`all` is not a valid enum value for path `roles.0`.",
+          field: "roles.0",
+        },
+      ],
+    });
+  });
+
+  it("maps a duplicate key to 409", async () => {
+    const res = mockRes();
+    await errorHandler(
+      { code: 11000, keyValue: { email: "a@b.c" } } as any,
+      req,
+      res,
+      next,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(409);
+  });
+
+  // An unexpected error must stay opaque to the caller — no stack, no internals.
+  it("keeps an unknown error generic to the client, but logs it", async () => {
+    const res = mockRes();
+    await errorHandler(new Error("kaboom"), req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith({
+      errors: [{ message: "Something went wrong" }],
+    });
+    expect(console.error).toHaveBeenCalled();
+  });
+});

--- a/src/middlewares/errors/handler.ts
+++ b/src/middlewares/errors/handler.ts
@@ -1,10 +1,31 @@
 import { Request, Response, NextFunction } from "express";
 import { CustomErr } from "../../errors/custom";
 
+/**
+ * Shape of a Mongoose ValidationError without importing mongoose here. A schema
+ * that rejects a value throws this, and it used to fall through to the generic
+ * branch — so a login blocked by a stale role enum told the user "Something went
+ * wrong" and told the operator nothing but a stack trace.
+ */
+interface MongooseValidationError {
+  name: "ValidationError";
+  errors: Record<string, { path?: string; message?: string }>;
+}
+
+const isValidationError = (err: any): err is MongooseValidationError =>
+  err?.name === "ValidationError" &&
+  err.errors &&
+  typeof err.errors === "object";
+
+/** Mongo duplicate-key error — a unique index rejecting an insert or update. */
+const isDuplicateKeyError = (err: any): boolean =>
+  err?.code === 11000 || err?.code === 11001;
+
 const errorHandler = async (
   err: Error,
   req: Request,
   res: Response,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   next: NextFunction,
 ) => {
   if (err instanceof CustomErr) {
@@ -13,7 +34,46 @@ const errorHandler = async (
     });
   }
 
-  console.log(err);
+  // Always log the real error with enough context to find the request that
+  // caused it — the generic client response is not the operator's only record.
+  const context = {
+    method: req.method,
+    path: req.originalUrl,
+    userId: (req as any).currentUser?.id,
+  };
+
+  if (isValidationError(err)) {
+    // The failing fields are schema constraint names, not secrets, and they are
+    // the actionable part. A stale enum value on a stored document surfaces here
+    // as e.g. `roles.0: 'all' is not a valid enum value` rather than a shrug.
+    const fields = Object.values(err.errors).map((e) => ({
+      field: e.path,
+      message: e.message,
+    }));
+
+    console.error("[validation]", { ...context, fields });
+
+    return res.status(400).send({
+      errors: fields.map((f) => ({
+        message: f.message ?? "Invalid value",
+        field: f.field,
+      })),
+    });
+  }
+
+  if (isDuplicateKeyError(err)) {
+    console.error("[duplicate-key]", {
+      ...context,
+      keyValue: (err as any).keyValue,
+    });
+    return res.status(409).send({
+      errors: [{ message: "That value is already taken." }],
+    });
+  }
+
+  // Genuinely unexpected. Log it in full; keep the client response opaque so an
+  // internal error never leaks a stack trace or an implementation detail.
+  console.error("[unhandled]", context, err);
 
   res.status(400).send({
     errors: [{ message: "Something went wrong" }],


### PR DESCRIPTION
A login on staging returned `{"errors":[{"message":"Something went wrong"}]}`. The real cause was a Mongoose ValidationError — a stored role value the narrowed schema now rejects — but it is not a CustomErr, so it fell through to the generic branch: the user learned nothing, and the operator got a bare stack trace with no request context.

The handler now recognises a ValidationError and returns its failing fields, which are schema constraint names rather than secrets and are the actionable part. Duplicate-key errors map to 409 instead of a misleading 400. Everything is logged with method, path and user id, so a failure is findable in the logs even when the client response stays opaque. A genuinely unexpected error still returns the generic message and never leaks internals.